### PR TITLE
if only DHL shipping is active, AJAX update does not work

### DIFF
--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="checkout.cart.shipping">
+            <arguments>
+                <argument name="jsLayout" xsi:type="array">
+                    <item name="components" xsi:type="array">
+                        <item name="summary-block-config" xsi:type="array">
+                            <item name="children" xsi:type="array">
+                                <item name="shipping-rates-validation" xsi:type="array">
+                                    <item name="children" xsi:type="array">
+                                        <item name="dhlexpress-rates-validation" xsi:type="array">
+                                            <item name="component" xsi:type="string">Dhl_ExpressRates/js/view/register-shipping-rates-validator</item>
+                                        </item>
+                                    </item>
+                                </item>
+                            </item>
+                        </item>
+                    </item>
+                </argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -25,7 +25,7 @@
                                                     <item name="children" xsi:type="array">
                                                         <item name="shipping-rates-validation" xsi:type="array">
                                                             <item name="children" xsi:type="array">
-                                                                <item name="dhl-express-rates-validation" xsi:type="array">
+                                                                <item name="dhlexpress-rates-validation" xsi:type="array">
                                                                     <item name="component" xsi:type="string">Dhl_ExpressRates/js/view/register-shipping-rates-validator</item>
                                                                 </item>
                                                             </item>


### PR DESCRIPTION
This is because the carrier code specified in view/frontend/layout/checkout_index_index.xml was incorrect.

See Magento docs https://devdocs.magento.com/guides/v2.3/howdoi/checkout/checkout_carrier.html - "You must add <your-validation-name> like %carrier%-rates-validation - where carrier has to match the actual carrier code."

This validator was being removed, because the code 'dhl-express' was not the same as the carrier code 'dhlexpress'. This happens in module-checkout/Block/Checkout/LayoutProcessor.php - it retrives a list of active carriers (where the config path carrier/CODE/active is set) and removes any validators whose code is not listed.

I added checkout_cart_index too for good measure, the same as built in providers.
